### PR TITLE
[COOK-1125] - Add centos/redhat support to cron recipe.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,18 @@
 # limitations under the License.
 #
 
-package "cron" do
+cron_package = case node['platform']
+when 'centos', 'redhat'
+  node.platform_version.to_f >= 6.0 ? "cronie" : "vixie-cron"
+else
+  "cron"
+end
+
+package cron_package do
   action :upgrade
 end
+
+service "crond" do
+  action [:start, :enable]
+end
+


### PR DESCRIPTION
These changes add support for centos/redhat to the cron recipe.
