### PR TITLE
COOK-1829 cron_d LWRP should imply cookbook cron by default

### DIFF
--- a/providers/d.rb
+++ b/providers/d.rb
@@ -6,7 +6,7 @@ end
 
 action :create do
   t = template "/etc/cron.d/#{new_resource.name}" do
-    cookbook new_resource.cookbook if new_resource.cookbook
+    cookbook new_resource.cookbook
     source "cron.d.erb"
     mode "0644"
     variables({

--- a/resources/d.rb
+++ b/resources/d.rb
@@ -1,7 +1,7 @@
 actions :create, :delete
 
 attribute :name, :kind_of => String, :name_attribute => true
-attribute :cookbook, :kind_of => [String, FalseClass], :default => false
+attribute :cookbook, :kind_of => String, :default => "cron"
 
 attribute :minute, :kind_of => [Integer, String], :default => "*"
 attribute :hour, :kind_of => [Integer, String], :default => "*"


### PR DESCRIPTION
Sets default cookbook of cron_d LWRP resource to "cron", removes extra if in provider.
