### PR TITLE
[COOK-3452] Add support for raspbian platform

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,6 @@ description      "Installs cron"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.2.7"
 
-%w{redhat centos scientific fedora amazon debian ubuntu}.each do |os|
+%w{redhat centos scientific fedora amazon debian ubuntu raspbian}.each do |os|
   supports os
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3452

Add support for raspian (debian wheezy derivative used by Raspberry Pi)

Tested  with latest raspbian image. Previous raspbian images identified themselves with a platform of debian, so should be backwards compatible.
