### PR TITLE
avoid newlines of env vars are empty

### DIFF
--- a/templates/default/cron.d.erb
+++ b/templates/default/cron.d.erb
@@ -1,7 +1,15 @@
 # Crontab for <%= @name %> managed by Chef. Changes will be overwritten.
-<% if @mailto -%>MAILTO=<%= @mailto %><% end -%>
-<% if @path -%>PATH=<%= @path %><% end -%>
-<% if @shell -%>SHELL=<%= @shell %><% end -%>
-<% if @home -%>HOME=<%= @home %><% end -%>
+<% if @mailto -%>
+MAILTO=<%= @mailto %>
+<% end -%>
+<% if @path -%>
+PATH=<%= @path %>
+<% end -%>
+<% if @shell -%>
+SHELL=<%= @shell %>
+<% end -%>
+<% if @home -%>
+HOME=<%= @home %>
+<% end -%>
 
 <%= @minute %> <%= @hour %> <%= @day %> <%= @month %> <%= @weekday %> <%= @user %> <%= @command %>


### PR DESCRIPTION
this is bugfix for previous commit to the template 29f06be3862945a01e46ab866671947e9ad698a1
i tested too. without any of the env vars, there's only one blank line:

```
# Crontab for daily-usage-report managed by Chef. Changes will be overwritten.

0 23 * * * appuser /srv/app/scripts/daily_report
```
