### PR TITLE
Make cron_d notification work

### DIFF
--- a/providers/d.rb
+++ b/providers/d.rb
@@ -1,3 +1,5 @@
+use_inline_resources if Chef::VERSION >= "11.0.0"
+
 action :delete do
   file "/etc/cron.d/#{new_resource.name}" do
     action :delete


### PR DESCRIPTION
Dunno about Chef 10, but in 11 parent will never know that template was updated, so notification propagation will never work.
In other words, notifies on cron_d resource doesn't work. updated_by_last_action? will run before the resource is updated always returning false.

PS: Funny thing is that this code is presented as example of such a propagation in opscode documentation. Prolly, should be fixed there also...
http://docs.opscode.com/chef/lwrps_custom.html#updated-by-last-action
