### PR TITLE
[COOK-4229] Gentoo support for Cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Requirements
 Platforms:
 - RHEL family
 - Debian family
+- Gentoo
 
 
 Resources and Providers

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      "Installs cron"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.2.9"
 
-%w{redhat centos scientific fedora amazon debian ubuntu raspbian}.each do |os|
+%w{redhat centos scientific fedora amazon debian ubuntu raspbian gentoo}.each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,10 +21,13 @@ package 'cron' do
   package_name case node['platform_family']
                when 'rhel', 'fedora'
                  node['platform_version'].to_f >= 6.0 ? 'cronie' : 'vixie-cron'
+               when 'gentoo'
+                  'vixie-cron'
                end
 end
 
 service 'cron' do
   service_name 'crond' if platform_family?('rhel', 'fedora')
+  service_name 'vixie-cron' if platform_family?('gentoo')
   action [:enable, :start]
 end


### PR DESCRIPTION
Added Gentoo to the OS support list. Gentoo is using vixie-cron
