### PR TITLE
[COOK-4337] fixing validations

### DIFF
--- a/resources/d.rb
+++ b/resources/d.rb
@@ -25,8 +25,8 @@ attribute :cookbook, :kind_of => String, :default => "cron"
 attribute :minute, :kind_of => [Integer, String], :default => "*", :callbacks => {"should be a valid minute spec" => lambda { |spec| validate_numeric(spec,0,59) } }
 attribute :hour, :kind_of => [Integer, String], :default => "*", :callbacks => {"should be a valid hour spec" => lambda { |spec| validate_numeric(spec,0,23) } }
 attribute :day, :kind_of => [Integer, String], :default => "*", :callbacks => {"should be a valid day spec" => lambda { |spec| validate_numeric(spec,1,31) } }
-attribute :month, :kind_of => [Integer, String], :default => "*", :callbacks => {"should be a valid month spec" => lambda { |spec| validate_month(spec,'mon') } }
-attribute :weekday, :kind_of => [Integer, String], :default => "*", :callbacks => {"should be a valid weekday spec" => lambda { |spec| validate_dow(spec,'dow') } }
+attribute :month, :kind_of => [Integer, String], :default => "*", :callbacks => {"should be a valid month spec" => lambda { |spec| validate_month(spec) } }
+attribute :weekday, :kind_of => [Integer, String], :default => "*", :callbacks => {"should be a valid weekday spec" => lambda { |spec| validate_dow(spec) } }
 
 attribute :command, :kind_of => String, :required => true
 
@@ -43,10 +43,15 @@ def initialize(*args)
 end
 
 def self.validate_numeric(spec,min,max)
+  if spec.is_a? Fixnum
+    return false unless spec >= min and spec <= max
+    return true
+  end
+
   # Lists of invidual values, ranges, and step values all share the validity range for type
   spec.split(/\/|-|,/).each do |x|
     next if x == '*'
-    if x.to_i.to_s == x
+    if x =~ /^\d+$/
       x = x.to_i
       return false unless x >= min and x <= max
     else
@@ -57,6 +62,7 @@ def self.validate_numeric(spec,min,max)
 end
 
 def self.validate_month(spec)
+  return true if spec == '*'
   # Named abbreviations are permitted but not as part of a range or with stepping
   if ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"].include? spec.downcase then
     return true
@@ -66,6 +72,7 @@ def self.validate_month(spec)
 end
 
 def self.validate_dow(spec)
+  return true if spec == '*'
   # Named abbreviations are permitted but not as part of a range or with stepping
   if ["sun", "mon", "tue", "wed", "thu", "fri", "sat"].include? spec.downcase then
     return true


### PR DESCRIPTION
- if the number was 00, it would not pass numeric validation
- validate_dow and validate_month only need one argument

and another error, if the numeric parameter was only a single number, it would fail at spec.split
