### PR TITLE
Add `environment' LWRP attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ Note: This LWRP does not function on Solaris platforms because they do not suppo
 * `command` - the command to run. Required.
 * `user` - the user to run as. Defaults to "root".
 * `mailto`, `path`, `home`, `shell` - set the corresponding environment variables in the cron.d file. No default.
+* `environment` - a Hash containing additional arbitrary environment variables under which the cron job will be run (similar to the `shell` LWRP).  No default.
 
 Definitions
 -----------
 ### `cron_manage`
-The `cron_manage` definition can be used to manage the `/etc/cron.allow` and `/etc/cron.deny` files.  
+The `cron_manage` definition can be used to manage the `/etc/cron.allow` and `/etc/cron.deny` files.
 Incude this cookbook as dependency to your cookbook and execute the definition as:
 
 The following will add the user mike to the `/etc/cron.allow` file:

--- a/providers/d.rb
+++ b/providers/d.rb
@@ -51,8 +51,9 @@ action :create do
                 :path => new_resource.path,
                 :home => new_resource.home,
                 :shell => new_resource.shell,
-                :comment => new_resource.comment
-    )
+                :comment => new_resource.comment,
+                :environment => new_resource.environment
+      )
     action :create
   end
   new_resource.updated_by_last_action(t.updated_by_last_action?)

--- a/resources/d.rb
+++ b/resources/d.rb
@@ -36,6 +36,7 @@ attribute :path, :kind_of => [String, NilClass]
 attribute :home, :kind_of => [String, NilClass]
 attribute :shell, :kind_of => [String, NilClass]
 attribute :comment, :kind_of => [String, NilClass]
+attribute :environment, :kind_of => Hash, :default => {}
 
 def initialize(*args)
   super

--- a/templates/default/cron.d.erb
+++ b/templates/default/cron.d.erb
@@ -11,6 +11,9 @@ SHELL=<%= @shell %>
 <% if @home -%>
 HOME=<%= @home %>
 <% end -%>
+<% @environment.each do |key, val| -%>
+<%= key %>=<%= val %>
+<% end -%>
 
 <% if @comment -%>
 # <%= @comment %>


### PR DESCRIPTION
Allow the user to specify an arbitrary environment to a cron job,
similar to the `environment` attribute that can be set in `shell`
and `bash` resources.  (Resolves #35)
