### PR TITLE
Allow user to specify file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ Note: This LWRP does not function on Solaris platforms because they do not suppo
 * `command` - the command to run. Required.
 * `user` - the user to run as. Defaults to "root".
 * `mailto`, `path`, `home`, `shell` - set the corresponding environment variables in the cron.d file. No default.
+* `mode` - the octal mode of the generated crontab file.  Defaults to `0644`.
 
 Definitions
 -----------
 ### `cron_manage`
-The `cron_manage` definition can be used to manage the `/etc/cron.allow` and `/etc/cron.deny` files.  
+The `cron_manage` definition can be used to manage the `/etc/cron.allow` and `/etc/cron.deny` files.
 Incude this cookbook as dependency to your cookbook and execute the definition as:
 
 The following will add the user mike to the `/etc/cron.allow` file:

--- a/providers/d.rb
+++ b/providers/d.rb
@@ -36,7 +36,7 @@ action :create do
   t = template "/etc/cron.d/#{new_resource.name}" do
     cookbook new_resource.cookbook
     source 'cron.d.erb'
-    mode '0644'
+    mode new_resource.mode
     variables(
                 :name => new_resource.name,
                 :predefined_value => new_resource.predefined_value,

--- a/resources/d.rb
+++ b/resources/d.rb
@@ -36,6 +36,7 @@ attribute :path, :kind_of => [String, NilClass]
 attribute :home, :kind_of => [String, NilClass]
 attribute :shell, :kind_of => [String, NilClass]
 attribute :comment, :kind_of => [String, NilClass]
+attribute :mode, :kind_of => [String, Integer], :default => '0644'
 
 def initialize(*args)
   super


### PR DESCRIPTION
crontab files can have sensitive data in them, so it's not always
appropriate for them to be world-readable.  An example would be
a crontab whose command contains secrets in them (e.g. AWS secret
keys).  So, give the user a way to specify the file mode.
