### PR TITLE
Check for numbers first to prevent Fixnum errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ cron Cookbook CHANGELOG
 =======================
 This file is used to list changes made in each version of the cron cookbook.
 
+v1.4.2 (2014-09-08)
+-------------------
+#31 - Fix up validate_month for Fixnums
+#32 - Fix upvalidate_dow for Fixnums
+
 v1.4.0 (2014-05-07)
 -------------------
 - [COOK-4628] Adding cron_manage to allow or deny users

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@opscode.com'
 license 'Apache 2.0'
 description 'Installs cron'
 
-version '1.4.1'
+version '1.4.2'
 
 recipe 'cron', 'Installs the cron package and starts the crond service.'
 

--- a/resources/d.rb
+++ b/resources/d.rb
@@ -72,17 +72,31 @@ def self.validate_numeric(spec, min, max)
 end
 
 def self.validate_month(spec)
-  # 1-12 are legal for months
-  return true if validate_numeric(spec, 1, 12)
-  return true if spec == '*'
-  # Named abbreviations are permitted but not as part of a range or with stepping
-  return true if %w(jan feb mar apr may jun jul aug sep oct nov dec).include? spec.downcase
+  case spec.class
+  when Fixnum
+    return validate_numeric(spec, 1, 12)
+  when String
+    return true if spec == '*'
+    # Named abbreviations are permitted but not as part of a range or with stepping
+    return true if %w(jan feb mar apry may jun jul aug sep oct nov dec).include? spec.downcase
+    # 1-12 are legal for months
+    return validate_numeric(spec, 1, 12)
+  else
+    return false
+  end
 end
 
 def self.validate_dow(spec)
-  # 0-7 are legal for days of week
-  return true if validate_numeric(spec, 0, 7)
-  return true if spec == '*'
-  # Named abbreviations are permitted but not as part of a range or with stepping
-  return true if %w(sun mon tue wed thu fri sat).include? spec.downcase
+  case spec
+  when Fixnum
+    return validate_numeric(spec, 0, 7)
+  when String
+    return true if spec == '*'
+    # Named abbreviations are permitted but not as part of a range or with stepping
+    return true if %w(sun mon tue wed thu fri sat).include? spec.downcase
+    # 0-7 are legal for days of week
+    return validate_numeric(spec, 0, 7)
+  else
+    return false
+  end
 end


### PR DESCRIPTION
When a number is passed (the default attribute) without this fix, a `.downcase` is attempted on a `Fixnum` type and causes an error. This changes the check to look for a valid digit first, then check for strings.
