### PR TITLE
fix broken kitchen setup (local)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,5 +31,5 @@ platforms:
 suites:
 - name: default
   run_list:
-  - recipe[cron::test]
+  - recipe[cron_test::default]
   attributes: {}


### PR DESCRIPTION
currently test-kitchen (non-cloud) setup is broken and executes the wrong cookbook.
