### PR TITLE
RE: #44, fix the case statement

### DIFF
--- a/resources/d.rb
+++ b/resources/d.rb
@@ -87,7 +87,7 @@ def self.validate_month(spec)
 end
 
 def self.validate_dow(spec)
-  case spec.class
+  case spec
   when Fixnum
     return validate_numeric(spec, 0, 7)
   when String


### PR DESCRIPTION
Fixes the bug introduced in #31 and #32, reported #44. In short:

```
irb(main):087:0* spec = '*'
=> "*"
irb(main):088:0> case spec.class
irb(main):089:1> when Fixnum
irb(main):090:1> puts 'Fixnum'
irb(main):091:1> when String
irb(main):092:1> puts 'String'
irb(main):093:1> end
=> nil
irb(main):094:0> case spec
irb(main):095:1> when Fixnum
irb(main):096:1> puts 'Fixnum'
irb(main):097:1> when String
irb(main):098:1> puts 'String'
irb(main):099:1> end
String
=> nil
```

Case internally uses `===`, hence the need to not be using `spec.class`. CC @someara @jordane
